### PR TITLE
Allow users to set the MQTT keep alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.0-beta.1] - Unreleased
 ### Added
 - Expose connection status in the SDK.
+- Expose a way to set the MQTT keepalive.
 
 ## [0.11.1] - 2020-05-19
 

--- a/astarte-transport/astartetransport.h
+++ b/astarte-transport/astartetransport.h
@@ -113,6 +113,7 @@ private:
     bool m_synced;
     bool m_rebootWhenConnectionFails;
     int m_rebootDelayMinutes;
+    int m_keepAliveSeconds;
     int m_inFlightIntrospectionMessageId;
 };
 }

--- a/transports/astartehttpendpoint.cpp
+++ b/transports/astartehttpendpoint.cpp
@@ -318,7 +318,6 @@ Hyperdrive::MQTTClientWrapper *HTTPEndpoint::createMqttClientWrapper()
     c->setCleanSession(false);
     c->setPublishQoS(Hyperdrive::MQTTClientWrapper::AtMostOnceQoS);
     c->setSubscribeQoS(Hyperdrive::MQTTClientWrapper::AtMostOnceQoS);
-    c->setKeepAlive(300);
     c->setIgnoreSslErrors(d->ignoreSslErrors);
 
     // SSL

--- a/transports/hyperdrivemqttclientwrapper.cpp
+++ b/transports/hyperdrivemqttclientwrapper.cpp
@@ -331,7 +331,7 @@ bool MQTTClientWrapper::connectToBroker()
 
             qCInfo(mqttWrapperDC) << "Starting mosquitto connection" << d->serverUrl.host() << d->serverUrl.port();
 
-            if ((rc = d->mosquitto->connect_async(qstrdup(d->serverUrl.host().toLatin1().constData()), d->serverUrl.port(), 60)) != MOSQ_ERR_SUCCESS) {
+            if ((rc = d->mosquitto->connect_async(qstrdup(d->serverUrl.host().toLatin1().constData()), d->serverUrl.port(), d->keepAlive)) != MOSQ_ERR_SUCCESS) {
                 qCWarning(mqttWrapperDC) << "Could not initiate async mosquitto connection! Return code " << rc;
                 Q_EMIT connectionFailed();
                 return false;

--- a/transports/hyperdrivemqttclientwrapper.h
+++ b/transports/hyperdrivemqttclientwrapper.h
@@ -73,7 +73,7 @@ public:
     void setIgnoreSslErrors(bool ignoreSslErrors);
     /// Note: this will only work if set before initializing the Client.
     void setCleanSession(bool cleanSession = true);
-    void setKeepAlive(quint64 seconds = 300);
+    void setKeepAlive(quint64 seconds);
     void setLastWill(const QByteArray &topic, const QByteArray &message, MQTTQoS qos, bool retained = false);
 
     int publish(const QByteArray &topic, const QByteArray &payload, MQTTQoS qos = DefaultQoS, bool retained = false);

--- a/transports/hyperdrivemqttclientwrapper_p.h
+++ b/transports/hyperdrivemqttclientwrapper_p.h
@@ -41,7 +41,7 @@ public:
                                                    , mosquitto(nullptr)
                                                    , status(MQTTClientWrapper::DisconnectedStatus)
                                                    , lwtRetained(false)
-                                                   , keepAlive(5 * 60)
+                                                   , keepAlive(60)
                                                    , cleanSession(false)
                                                    , sessionPresent(false)
                                                    , publishQoS(1)


### PR DESCRIPTION
This makes it possible to configure an higher keepalive to decrease data usage
or a lower one to work with Load Balancers that terminate inactive connections
early.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>