### PR TITLE
Add support for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.1] - Unreleased
 ### Added
 - Add public functions for connecting (connectToAstarte) and disconnecting (disconnectFromAstarte).
+- Add support for all array types by adding QList<T> overloads to sendData
 
 ### Changed
 - Make the SDK build with Qt versions earlier than 5.6. http redirects will not be supported on

--- a/astarte-device-sdk/AstarteDeviceSDK.cpp
+++ b/astarte-device-sdk/AstarteDeviceSDK.cpp
@@ -393,3 +393,29 @@ bool AstarteDeviceSDK::disconnectFromAstarte()
 
   return m_astarteTransport->disconnectFromBroker();
 }
+
+template <typename T> bool AstarteDeviceSDK::sendData(const QByteArray &interface, const QByteArray &path,
+                                                      const QList<T> &valueList, const QDateTime &timestamp, const QVariantHash &metadata)
+{
+    if (!m_producers.contains(interface)) {
+        qCWarning(astarteDeviceSDKDC) << "No producers for interface " << interface;
+        return false;
+    }
+
+    QList<QVariant> variantValue;
+    variantValue.reserve(valueList.length());
+
+    for (int i = 0; i < valueList.length(); i++){
+        variantValue.append(QVariant(valueList[i]));
+    }
+
+    return m_producers.value(interface)->sendData(variantValue, path, timestamp, metadata);
+}
+
+template bool AstarteDeviceSDK::sendData(const QByteArray &interface, const QByteArray &path, const QList<QByteArray> &value, const QDateTime &timestamp, const QVariantHash &metadata);
+template bool AstarteDeviceSDK::sendData(const QByteArray &interface, const QByteArray &path, const QList<int> &value, const QDateTime &timestamp, const QVariantHash &metadata);
+template bool AstarteDeviceSDK::sendData(const QByteArray &interface, const QByteArray &path, const QList<qlonglong> &value, const QDateTime &timestamp, const QVariantHash &metadata);
+template bool AstarteDeviceSDK::sendData(const QByteArray &interface, const QByteArray &path, const QList<double> &value, const QDateTime &timestamp, const QVariantHash &metadata);
+template bool AstarteDeviceSDK::sendData(const QByteArray &interface, const QByteArray &path, const QList<bool> &value, const QDateTime &timestamp, const QVariantHash &metadata);
+template bool AstarteDeviceSDK::sendData(const QByteArray &interface, const QByteArray &path, const QList<QDateTime> &value, const QDateTime &timestamp, const QVariantHash &metadata);
+template bool AstarteDeviceSDK::sendData(const QByteArray &interface, const QByteArray &path, const QList<QString> &value, const QDateTime &timestamp, const QVariantHash &metadata);

--- a/astarte-device-sdk/AstarteDeviceSDK.h
+++ b/astarte-device-sdk/AstarteDeviceSDK.h
@@ -62,6 +62,9 @@ public:
 
     bool sendData(const QByteArray &interface, const QVariantHash &value, const QVariantHash &metadata);
 
+    template <typename T> bool sendData(const QByteArray &interface, const QByteArray &path, const QList<T> &value,
+            const QDateTime &timestamp = QDateTime(), const QVariantHash &metadata = QVariantHash());
+
     bool sendUnset(const QByteArray &interface, const QByteArray &path);
 
     ConnectionStatus connectionStatus() const;

--- a/astarte-utils/AstarteGenericProducer.cpp
+++ b/astarte-utils/AstarteGenericProducer.cpp
@@ -127,6 +127,18 @@ bool AstarteGenericProducer::sendData(const QVariant &value, const QByteArray &t
     return false;
 }
 
+bool AstarteGenericProducer::sendData(const QList<QVariant> &value, const QByteArray &target, const QDateTime &timestamp, const QVariantHash &metadata)
+{
+    // TODO: checks
+    QHash<QByteArray, QByteArray> attributes;
+    attributes.insert("interfaceType", QByteArray::number(static_cast<int>(m_interfaceType)));
+    // TODO: handle reliability, retention and expiry
+
+    sendDataOnEndpoint(value, target, attributes, timestamp, metadata);
+
+    return true;
+}
+
 bool AstarteGenericProducer::sendData(const QVariantHash &value, const QByteArray &target, const QDateTime &timestamp, const QVariantHash &metadata)
 {
     // TODO: verify path match

--- a/astarte-utils/AstarteGenericProducer.h
+++ b/astarte-utils/AstarteGenericProducer.h
@@ -39,6 +39,8 @@ public:
 
     bool sendData(const QVariant &value, const QByteArray &target,
             const QDateTime &timestamp = QDateTime(), const QVariantHash &metadata = QVariantHash());
+    bool sendData(const QList<QVariant> &value, const QByteArray &target,
+            const QDateTime &timestamp = QDateTime(), const QVariantHash &metadata = QVariantHash());
     bool sendData(const QVariantHash &value, const QByteArray &target,
             const QDateTime &timestamp = QDateTime(), const QVariantHash &metadata = QVariantHash());
     bool unsetPath(const QByteArray &target);

--- a/hyperspace/BSONSerializer.cpp
+++ b/hyperspace/BSONSerializer.cpp
@@ -31,6 +31,7 @@
 #define BSON_TYPE_DOUBLE    '\x01'
 #define BSON_TYPE_STRING    '\x02'
 #define BSON_TYPE_DOCUMENT  '\x03'
+#define BSON_TYPE_ARRAY     '\x04'
 #define BSON_TYPE_BINARY    '\x05'
 #define BSON_TYPE_BOOLEAN   '\x08'
 #define BSON_TYPE_DATETIME  '\x09'
@@ -173,6 +174,19 @@ void BSONSerializer::appendBooleanValue(const char *name, bool value)
     m_doc.append(BSON_TYPE_BOOLEAN);
     m_doc.append(name, strlen(name) + 1);
     m_doc.append(value ? '\1' : '\0');
+}
+
+void BSONSerializer::appendArray(const char *name, const QList<QVariant> &value)
+{
+    m_doc.append(BSON_TYPE_ARRAY);
+
+    BSONSerializer subDocument;
+    for (int i = 0; i < value.length(); i++) {
+        subDocument.appendValue(QString::number(i).toLatin1().constData(), value[i]);
+    }
+    subDocument.appendEndOfDocument();
+    m_doc.append(name, strlen(name) + 1);
+    m_doc.append(subDocument.document());
 }
 
 void BSONSerializer::appendValue(const char *name, const QVariant &value)

--- a/hyperspace/BSONSerializer.h
+++ b/hyperspace/BSONSerializer.h
@@ -49,6 +49,7 @@ class BSONSerializer
         void appendDateTime(const char *name, const QDateTime &dateTime);
         void appendBooleanValue(const char *name, bool value);
 
+        void appendArray(const char *name, const QList<QVariant> &value);
         void appendValue(const char *name, const QVariant &value);
         void appendDocument(const char *name, const QVariantHash &document);
         void appendDocument(const char *name, const QVariantMap &document);

--- a/hyperspace/ProducerAbstractInterface.cpp
+++ b/hyperspace/ProducerAbstractInterface.cpp
@@ -272,6 +272,21 @@ void ProducerAbstractInterface::sendDataOnEndpoint(const QVariantHash &value, co
     sendRawDataOnEndpoint(serializer.document(), target, attributes);
 }
 
+void ProducerAbstractInterface::sendDataOnEndpoint(QList<QVariant> value, const QByteArray &target,
+        const QHash<QByteArray, QByteArray> &attributes, const QDateTime &timestamp, const QVariantHash &metadata)
+{
+    Util::BSONSerializer serializer;
+    serializer.appendArray("v", value);
+    if (!timestamp.isNull() && timestamp.isValid()) {
+        serializer.appendDateTime("t", timestamp);
+    }
+    if (!metadata.isEmpty()) {
+        serializer.appendDocument("m", metadata);
+    }
+    serializer.appendEndOfDocument();
+    sendRawDataOnEndpoint(serializer.document(), target, attributes);
+}
+
 bool ProducerAbstractInterface::payloadToValue(const QByteArray &payload, QByteArray *value)
 {
     Util::BSONDocument doc(payload);

--- a/hyperspace/ProducerAbstractInterface.h
+++ b/hyperspace/ProducerAbstractInterface.h
@@ -91,6 +91,9 @@ class ProducerAbstractInterface : public AbstractWaveTarget
         void sendDataOnEndpoint(const QVariantHash &value, const QByteArray &target,
             const QHash<QByteArray, QByteArray> &attributes = QHash<QByteArray, QByteArray>(), const QDateTime &timestamp = QDateTime(), const QVariantHash &metadata = QVariantHash());
 
+        void sendDataOnEndpoint(QList<QVariant> value, const QByteArray &target,
+            const QHash<QByteArray, QByteArray> &attributes = QHash<QByteArray, QByteArray>(), const QDateTime &timestamp = QDateTime(), const QVariantHash &metadata = QVariantHash());
+
         bool payloadToValue(const QByteArray &payload, QByteArray *value);
         bool payloadToValue(const QByteArray &payload, int *value);
         bool payloadToValue(const QByteArray &payload, qint64 *value);


### PR DESCRIPTION
Add support for all array types by adding `QList<T>` overloads to sendData

| `QList<T> `                  | Astarte type      |
| ---------------------------- | -------------------- |
| `QList<QByteArray>` | binaryblobarray|
| `QList<int>`               | integerarray      |
|` QList<qlonglong>`   |longintegerarray |
| `QList<double>`        |doublearray        |
| `QList<bool>`            | booleanarray    |
| `QList<QDateTime>` |datetimearray    |
| `QList<QString>`       | stringarray        |

No runtime checks are performed