### PR TITLE
Fix Property Unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Deprecate `endpoint` in the configuration, introduce `pairingUrl` and `realm` in the configuration
   to replace it.
 
+### Fixed
+- Fixed `sendUnset` bug that prevented it from working.
+
 ## [1.0.0] - 2021-06-28
 
 ## [1.0.0-rc.0] - 2021-05-10

--- a/astarte-utils/AstarteGenericProducer.cpp
+++ b/astarte-utils/AstarteGenericProducer.cpp
@@ -186,7 +186,10 @@ bool AstarteGenericProducer::unsetPath(const QByteArray &target)
         }
 
         if (mappingMatches) {
-            sendRawDataOnEndpoint(QByteArray(), target);
+            QHash<QByteArray, QByteArray> attributes;
+            attributes.insert("interfaceType", QByteArray::number(static_cast<int>(m_interfaceType)));
+
+            sendRawDataOnEndpoint(QByteArray(), target, attributes);
             return true;
         }
     }


### PR DESCRIPTION
The missing interfaceType attribute was preventing the data to be sent, when the function was called from sendUnset
