### PR TITLE
Make array types work with object aggregated datastreams

### DIFF
--- a/astarte-device-sdk/AstarteDeviceSDK.cpp
+++ b/astarte-device-sdk/AstarteDeviceSDK.cpp
@@ -339,6 +339,19 @@ bool AstarteDeviceSDK::sendData(const QByteArray &interface, const QVariantHash 
         QString normalizedPath = i.key();
         normalizedPath.remove(0, trailingPath.size() + 1);
         normalizedValues.insert(normalizedPath, i.value());
+
+        QVariant value = i.value();
+
+        if (value.type() == QVariant::List){
+            QList<QVariant> valueList = value.toList();
+            for (int j = 0; j < valueList.length(); j++) {
+                if (valueList.at(j).type() != valueList.at(0).type()) {
+                    qCWarning(astarteDeviceSDKDC) << "Inconsistent types in QVariant array";
+                    return false;
+                }
+            }
+        }
+
     }
     // If we got here, verification was ok. Let's go.
 

--- a/hyperspace/BSONSerializer.cpp
+++ b/hyperspace/BSONSerializer.cpp
@@ -213,6 +213,9 @@ void BSONSerializer::appendValue(const char *name, const QVariant &value)
         case QVariant::String:
             appendString(name, value.toString());
             break;
+        case QVariant::List:
+            appendArray(name, value.toList());
+            break;
         default:
             qWarning() << "Can't find valid type for " << value;
     }


### PR DESCRIPTION
Add support for array types (such as string array) also in object aggregated datastreams.
In order to get them working, the value is converted to `QList<QVariant>`.