### PR TITLE
Emit connectionStatusChanged after handling the status internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fixed `sendUnset` bug that prevented it from working.
+- Emit `connectionStatusChanged` only after performing the internal connection status handling (e.g.
+  publishing the introspection).
 
 ## [1.0.0] - 2021-06-28
 

--- a/astarte-transport/astartetransport.cpp
+++ b/astarte-transport/astartetransport.cpp
@@ -423,8 +423,6 @@ void AstarteTransport::forceNewPairing()
 
 void AstarteTransport::onStatusChanged(MQTTClientWrapper::Status status)
 {
-    emit connectionStatusChanged();
-
     if (status == MQTTClientWrapper::ConnectedStatus) {
         // We're connected, stop the reboot timer
         qCDebug(astarteTransportDC) << "Connected, stopping the reboot timer";
@@ -447,6 +445,8 @@ void AstarteTransport::onStatusChanged(MQTTClientWrapper::Status status)
             m_rebootTimer->start();
         }
     }
+
+    emit connectionStatusChanged();
 }
 
 AstarteTransport::ConnectionStatus AstarteTransport::connectionStatus() const


### PR DESCRIPTION
Allow using the signal to be sure the device is connected and with its
introspection already sent before starting to publish.

Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>