### PR TITLE
Accept QList<T> for object fields 

### DIFF
--- a/hyperspace/BSONSerializer.cpp
+++ b/hyperspace/BSONSerializer.cpp
@@ -182,14 +182,14 @@ void BSONSerializer::appendArray(const char *name, const QList<QVariant> &value)
 
     BSONSerializer subDocument;
     for (int i = 0; i < value.length(); i++) {
-        subDocument.appendValue(QString::number(i).toLatin1().constData(), value[i]);
+        subDocument.appendValue(QString::number(i).toLatin1().constData(), value[i], true);
     }
     subDocument.appendEndOfDocument();
     m_doc.append(name, strlen(name) + 1);
     m_doc.append(subDocument.document());
 }
 
-void BSONSerializer::appendValue(const char *name, const QVariant &value)
+void BSONSerializer::appendValue(const char *name, const QVariant &value, bool scalarOnly)
 {
     switch (value.type()) {
         case QVariant::Bool:
@@ -217,6 +217,11 @@ void BSONSerializer::appendValue(const char *name, const QVariant &value)
             appendArray(name, value.toList());
             break;
         default:
+            if (value.canConvert<QList<QVariant>>() && !scalarOnly) {
+                appendArray(name, value.value<QList<QVariant>>());
+                break;
+            }
+
             qWarning() << "Can't find valid type for " << value;
     }
 }

--- a/hyperspace/BSONSerializer.h
+++ b/hyperspace/BSONSerializer.h
@@ -50,7 +50,7 @@ class BSONSerializer
         void appendBooleanValue(const char *name, bool value);
 
         void appendArray(const char *name, const QList<QVariant> &value);
-        void appendValue(const char *name, const QVariant &value);
+        void appendValue(const char *name, const QVariant &value, bool scalarOnly=false);
         void appendDocument(const char *name, const QVariantHash &document);
         void appendDocument(const char *name, const QVariantMap &document);
 


### PR DESCRIPTION
As of #37, `sendData` for an object aggregated datastream was accepting only `QList<QVariant>` for array types, with this patch every `QList<T>` that can be automatically converted to `QList<QVariant>` is accepted


```c++
    data["..."] = QVariant::fromValue<QList<QString>>({ QString("te"), QString("st") });
    data["..."] = QVariant::fromValue<QList<int>>( { 20, 21 } );
    data["..."] = QVariant::fromValue<QList<QString>>({ QString("ml"), QString("kg") });

    m_sdk->sendData("...", data, QDateTime::currentDateTime());
```