### PR TITLE
Remove compilation warnings from SDK

### DIFF
--- a/astarte-utils/AstarteGenericConsumer.cpp
+++ b/astarte-utils/AstarteGenericConsumer.cpp
@@ -57,6 +57,7 @@ void AstarteGenericConsumer::populateTokensAndStates()
 Hyperspace::ProducerConsumer::ConsumerAbstractAdaptor::DispatchResult AstarteGenericConsumer::dispatch(int i, const QByteArray &payload,
                                                                                                        const QList<QByteArray> &inputTokens)
 {
+    Q_UNUSED(i);
     QHash<QByteArray, QByteArrayList>::const_iterator it;
 
     for (it = m_mappingToTokens.constBegin(); it != m_mappingToTokens.constEnd(); it++) {

--- a/astarte-utils/AstarteGenericProducer.cpp
+++ b/astarte-utils/AstarteGenericProducer.cpp
@@ -258,5 +258,8 @@ void AstarteGenericProducer::populateTokensAndStates()
 Hyperspace::ProducerConsumer::ProducerAbstractInterface::DispatchResult AstarteGenericProducer::dispatch(int i, const QByteArray &payload,
                                                                                                          const QList<QByteArray> &inputTokens)
 {
+    Q_UNUSED(i);
+    Q_UNUSED(payload);
+    Q_UNUSED(inputTokens);
     return IndexNotFound;
 }

--- a/astarte-utils/ValidateInterfaceOperation.cpp
+++ b/astarte-utils/ValidateInterfaceOperation.cpp
@@ -33,6 +33,7 @@ ValidateInterfaceOperation::ValidateInterfaceOperation(const QString &path, QObj
     : m_checker(new QJsonSchemaChecker())
     , m_path(path)
 {
+    Q_UNUSED(parent);
 }
 
 ValidateInterfaceOperation::~ValidateInterfaceOperation()

--- a/hyperspace/ConsumerAbstractAdaptor.cpp
+++ b/hyperspace/ConsumerAbstractAdaptor.cpp
@@ -98,7 +98,7 @@ int ConsumerAbstractAdaptor::dispatchIndex(const QList<QByteArray> &inputTokens)
 
     QList<int> nextStates;
 
-    for (const QByteArray token : inputTokens) {
+    for (const QByteArray &token : inputTokens) {
         nextStates = QList<int>();
 
         for (int i = 0; i < currentStates.count(); i++) {

--- a/hyperspace/ProducerAbstractInterface.cpp
+++ b/hyperspace/ProducerAbstractInterface.cpp
@@ -103,7 +103,7 @@ int ProducerAbstractInterface::dispatchIndex(const QList<QByteArray> &inputToken
 
     QList<int> nextStates;
 
-    for (const QByteArray token : inputTokens) {
+    for (const QByteArray &token : inputTokens) {
         nextStates = QList<int>();
 
         for (int i = 0; i < currentStates.count(); i++) {


### PR DESCRIPTION
Deprecation warnings still unresolved

1. `qrand/qsrand` is deprecated: use QRandomGenerator instead: Since QT 5.10
2. `RSA* RSA_new()` is deprecated: Since OpenSSL 3.0
3. `RSA_generate_key_ex(RSA*, int, BIGNUM*, BN_GENCB*)` is deprecated: Since OpenSSL 3.0
4. `RSA_check_key(const RSA*)` is deprecated: Since OpenSSL 3.0 
5. `RSA_free(RSA*)` is deprecated: Since OpenSSL 3.0
