### PR TITLE
Receive array types from server owned interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.3] - Unreleased
+### Added
+- Add support for receiving array types.
+
 ### Changed
 - Do not use qWarning() for mosquitto debug messages.
 

--- a/astarte-utils/AstarteGenericConsumer.cpp
+++ b/astarte-utils/AstarteGenericConsumer.cpp
@@ -93,6 +93,13 @@ Hyperspace::ProducerConsumer::ConsumerAbstractAdaptor::DispatchResult AstarteGen
             }
         }
 
+        if (m_mappingToArrayType.contains(matchedMapping)){
+            QList<QVariant> value;
+            if (!payloadToValue(payload, &value)) return CouldNotConvertPayload;
+            parent()->receiveValue(interface(), path, value);
+            return Success;
+        }
+
         switch (m_mappingToType.value(matchedMapping)) {
             case QMetaType::Bool: {
                 bool value;

--- a/hyperspace/BSONDocument.h
+++ b/hyperspace/BSONDocument.h
@@ -47,6 +47,7 @@ class BSONDocument
         int32_t int32Value(const char *name, int32_t defaultValue = 0) const;
         int64_t int64Value(const char *name, int64_t defaultValue = 0) const;
         bool booleanValue(const char *name, bool defaultValue = false) const;
+        QList<QVariant> listVariantValue(const char *name, const QList<QVariant> &defaultValue = QList<QVariant>()) const;
 
         BSONDocument subdocument(const char *name) const;
         QHash<QByteArray, QByteArray> byteArrayValuesHash() const;

--- a/hyperspace/ConsumerAbstractAdaptor.cpp
+++ b/hyperspace/ConsumerAbstractAdaptor.cpp
@@ -214,6 +214,18 @@ bool ConsumerAbstractAdaptor::payloadToValue(const QByteArray &payload, QDateTim
     return true;
 }
 
+bool ConsumerAbstractAdaptor::payloadToValue(const QByteArray &payload, QList<QVariant> *value)
+{
+  Util::BSONDocument doc(payload);
+  if (Q_UNLIKELY(!doc.isValid() || !doc.contains("v"))) {
+      *value = QList<QVariant>();
+      return false;
+  }
+
+  *value = doc.listVariantValue("v");
+  return true;
+}
+
 }
 
 }

--- a/hyperspace/ConsumerAbstractAdaptor.h
+++ b/hyperspace/ConsumerAbstractAdaptor.h
@@ -68,6 +68,7 @@ class ConsumerAbstractAdaptor : public AbstractWaveTarget
         bool payloadToValue(const QByteArray &payload, double *value);
         bool payloadToValue(const QByteArray &payload, QString *value);
         bool payloadToValue(const QByteArray &payload, QDateTime *value);
+        bool payloadToValue(const QByteArray &payload, QList<QVariant> *value);
 
     private:
         class Private;


### PR DESCRIPTION
The value dispatched by `AstarteDeviceSDK::dataReceived` signal when an array types incoming from server it will be encapsulated in a `QList<QVariant>`. 