### PR TITLE
Handle the session present from CONNACK flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - Unreleased
+### Added
+- Handle session present from CONNACK flag since Mosquitto 1.5.
+
 ## [1.0.4] - 2022-10-25
 
 ## [1.0.3] - 2022-07-08

--- a/transports/hyperdrivemqttclientwrapper.cpp
+++ b/transports/hyperdrivemqttclientwrapper.cpp
@@ -54,7 +54,7 @@ void MQTTClientWrapperPrivate::setStatus(MQTTClientWrapper::Status s)
     }
 }
 
-void MQTTClientWrapperPrivate::on_connect(int rc)
+void MQTTClientWrapperPrivate::handleConnack(int rc)
 {
     qCInfo(mqttWrapperDC) << "Connected to broker returned!";
 
@@ -64,13 +64,27 @@ void MQTTClientWrapperPrivate::on_connect(int rc)
     Q_EMIT q->connackReceived();
 
     if (rc == MOSQ_ERR_SUCCESS) {
-        // TODO: check is session present with patched mosquitto
-        sessionPresent = false;
         qCInfo(mqttWrapperDC) << "Connected to broker, session present: " << sessionPresent;
         setStatus(MQTTClientWrapper::ConnectedStatus);
     } else {
         qCInfo(mqttWrapperDC) << "Could not connected to broker!" << rc;
     }
+}
+
+void MQTTClientWrapperPrivate::on_connect(int rc)
+{
+    if (rc == MOSQ_ERR_SUCCESS) {
+        sessionPresent = false;
+    }
+    this->handleConnack(rc);
+}
+
+void MQTTClientWrapperPrivate::on_connect_with_flags(int rc, int flags)
+{
+    if (rc == MOSQ_ERR_SUCCESS) {
+        sessionPresent = isSessionPresent(flags);
+    }
+    this->handleConnack(rc);
 }
 
 void MQTTClientWrapperPrivate::on_disconnect(int rc)
@@ -141,6 +155,10 @@ void MQTTClientWrapperPrivate::on_publish(int mid)
     Q_EMIT q->publishConfirmed(mid);
 }
 
+bool MQTTClientWrapperPrivate::isSessionPresent(int flags)
+{
+    return (flags & 0x1) != 0;
+}
 
 MQTTClientWrapper::MQTTClientWrapper(const QUrl &host, QObject *parent)
     : MQTTClientWrapper(host, QByteArray(), parent)

--- a/transports/hyperdrivemqttclientwrapper_p.h
+++ b/transports/hyperdrivemqttclientwrapper_p.h
@@ -79,6 +79,7 @@ public:
 
     // MQTT CALLBACKS
     void on_connect(int rc);
+    void on_connect_with_flags(int rc, int flags);
     void on_disconnect(int rc);
     void on_publish(int mid);
     void on_message(const struct mosquitto_message *message);
@@ -86,6 +87,10 @@ public:
     void on_unsubscribe(int mid);
     void on_log(int level, const char *str);
     void on_error();
+
+private:
+    void handleConnack(int rc);
+    static bool isSessionPresent(int flags);
 };
 
 class HyperdriveMosquittoClient : public mosqpp::mosquittopp
@@ -97,7 +102,11 @@ public:
     virtual ~HyperdriveMosquittoClient() {}
 
     // MQTT CALLBACKS. Just redirect to our private class
+#if LIBMOSQUITTO_MAJOR <= 1 && LIBMOSQUITTO_MINOR < 5
     inline virtual void on_connect(int rc) override { d->on_connect(rc); }
+#else
+    inline virtual void on_connect_with_flags(int rc, int flags) override { d->on_connect_with_flags(rc, flags); }
+#endif
     inline virtual void on_disconnect(int rc) override { d->on_disconnect(rc); }
     inline virtual void on_publish(int mid) override { d->on_publish(mid); }
     inline virtual void on_message(const struct mosquitto_message *message) override { d->on_message(message); }


### PR DESCRIPTION
Use connect_with_flags function that expose the connect flags parameter.

However, the connect_with_flags is available since **mosquitto 1.5**, so if you use an earlier version, the **session present** is always false.