### PR TITLE
Saving credentialsSecret already present in config

### DIFF
--- a/transports/astartehttpendpoint.cpp
+++ b/transports/astartehttpendpoint.cpp
@@ -162,6 +162,11 @@ void HTTPEndpointPrivate::ensureCredentialsSecret()
     provider->setHardwareId(hardwareId);
     provider->setNAM(nam);
     provider->setSslConfiguration(sslConfiguration);
+
+    if (!this->credentialsSecret.isEmpty()) {
+        provider->saveCredentialsSecret(this->credentialsSecret);
+    }
+
     credentialsSecretProvider = provider;
 
     QObject::connect(credentialsSecretProvider, &CredentialsSecretProvider::credentialsSecretReady, q, [this, q] () {


### PR DESCRIPTION
If a credentialsSecret is present in the device configuration, it must also be saved in the endopoint_crypto.conf file.